### PR TITLE
Add MapLibre-based 3D map support

### DIFF
--- a/custom_components/ha_tracker/www/css/styles.css
+++ b/custom_components/ha_tracker/www/css/styles.css
@@ -137,6 +137,60 @@ body.loaded {
   z-index: 0;
 }
 
+.pitch-control {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4px;
+  gap: 2px;
+  min-width: 40px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+}
+
+.pitch-control__label {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 6px;
+  color: #1e293b;
+}
+
+.pitch-control__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 30px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1f2937;
+  text-decoration: none;
+  border-top: 1px solid rgba(15, 23, 42, 0.12);
+}
+
+.pitch-control__btn:first-of-type {
+  border-top: none;
+}
+
+.pitch-control__btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.pitch-control__btn:hover {
+  background: color-mix(in srgb, #e2e8f0 88%, white 12%);
+}
+
+.pitch-control--disabled,
+.pitch-control--disabled .pitch-control__btn {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.pitch-control--disabled .pitch-control__btn {
+  pointer-events: none;
+}
+
 /* ===== Panel lateral de formularios ===== */
 #forms-container {
   width: 400px;

--- a/custom_components/ha_tracker/www/js/screens/filter.js
+++ b/custom_components/ha_tracker/www/js/screens/filter.js
@@ -2,7 +2,7 @@
 // FILTER
 //
 
-import { map } from '../utils/map.js';
+import { map, focusMapOn, invalidateMapSize, adjustToDefault3DPitch } from '../utils/map.js';
 import { formatDate, fmt0, fmt2, use_imperial, DEFAULT_ALPHA } from '../globals.js';
 import { fetchFilteredPositions, fetchResetReverseGeocodeCache } from '../ha/fetch.js';
 import { handleZonePosition, showZone, getZoneStyleById } from '../screens/zones.js';
@@ -768,8 +768,8 @@ function openInfoPopup(lat, lon, lastUpdated, speed, isStop = false) {
         .setContent(html)
         .openOn(map);
 
-    map.invalidateSize();
-    map.setView([lat, lon], map.getZoom());
+    invalidateMapSize();
+    focusMapOn(lat, lon, { ensure3d: true });
 }
 
 function closeInfoPopup() {
@@ -922,6 +922,7 @@ async function addRouteLine(
     }
 
     map.fitBounds(L.latLngBounds(coords));
+    adjustToDefault3DPitch({ animate: false });
 }
 
 // Curva Catmull-Rom centrípeta que INTERPOLA los puntos (pasa por ellos)

--- a/custom_components/ha_tracker/www/js/screens/persons.js
+++ b/custom_components/ha_tracker/www/js/screens/persons.js
@@ -5,7 +5,7 @@
 import { formatDate, geocodeTime, geocodeDistance, use_imperial, DEFAULT_ALPHA } from '../globals.js';
 import { fetchPersons, fetchDevices } from '../ha/fetch.js';
 import { handleZonePosition } from '../screens/zones.js';
-import { map, isValidCoordinates, getDistanceFromLatLonInMeters } from '../utils/map.js';
+import { map, isValidCoordinates, getDistanceFromLatLonInMeters, focusMapOn, invalidateMapSize, adjustToDefault3DPitch } from '../utils/map.js';
 import { t } from '../utils/i18n.js';
 import { requestAddress, cancelAddress } from '../utils/geocode.js';
 import { toRgba } from '../utils/dialogs.js';
@@ -147,8 +147,8 @@ export async function handlePersonsSelection(personId) {
     }
 
     selectedPerson.openPopup();
-    map.invalidateSize();
-    map.setView([lat, lng], map.getZoom());
+    invalidateMapSize();
+    focusMapOn(lat, lng, { ensure3d: true });
 }
 
 export function updatePersonsFilter() {
@@ -207,6 +207,7 @@ export async function fitMapToAllPersons() {
 
         const bounds = L.latLngBounds(coords);
         map.fitBounds(bounds);
+        adjustToDefault3DPitch({ animate: false });
     } catch (error) {
         console.error("Error doing fitMapToAllDevices:", error);
     }
@@ -304,9 +305,9 @@ async function updatePersonsMarkers() {
                 })
                 .on('click', async() => {
                     await handlePersonRowSelection(personId);
-                    map.invalidateSize();
+                    invalidateMapSize();
                     const ll = personsMarkers[personId].getLatLng();
-                    map.setView(ll, map.getZoom());
+                    focusMapOn(ll.lat, ll.lng, { ensure3d: true });
                     personsMarkers[personId].openPopup();
                 });
         }

--- a/custom_components/ha_tracker/www/js/screens/zones.js
+++ b/custom_components/ha_tracker/www/js/screens/zones.js
@@ -3,7 +3,7 @@
 //
 
 import { isAdmin, fmt0, use_imperial, DEFAULT_COLOR, DEFAULT_ALPHA } from '../globals.js';
-import { map, getDistanceFromLatLonInMeters } from '../utils/map.js';
+import { map, getDistanceFromLatLonInMeters, focusMapOn, invalidateMapSize, adjustToDefault3DPitch } from '../utils/map.js';
 import { deleteZone, updateZone, createZone, fetchZones } from '../ha/fetch.js';
 import { updatePersonsTable } from '../screens/persons.js';
 import { t, tWithVars } from '../utils/i18n.js';
@@ -205,6 +205,7 @@ async function updateZoneMarkers() {
                 map.fitBounds(circle.getBounds(), {
                     padding: [24, 24]
                 });
+                adjustToDefault3DPitch({ animate: false });
 
                 // Abre el popup del círculo
                 circle.openPopup();
@@ -680,7 +681,9 @@ export async function showZone(idZone) {
   const key = String(idZone);
   const circle = zoneMarkers[key];
   if (circle) {
-    map.setView(circle.getLatLng(), map.getZoom());
+    invalidateMapSize();
+    const ll = circle.getLatLng();
+    focusMapOn(ll.lat, ll.lng, { ensure3d: true });
     circle.openPopup();
   } else {
     console.error("Marker for zone not found:", key);
@@ -805,6 +808,7 @@ async function updateZonesTable() {
                 map.fitBounds(circleBounds, {
                     padding: [24, 24]
                 });
+                adjustToDefault3DPitch({ animate: false });
                 marker.openPopup(); // Mostrar el popup
             } else {
                 console.error("No marker found for the zone:", id);

--- a/custom_components/ha_tracker/www/js/utils/map.js
+++ b/custom_components/ha_tracker/www/js/utils/map.js
@@ -507,6 +507,16 @@ export async function initMap() {
 
         } catch (error) {
                 console.error('Error starting map:', error);
+
+                try {
+                        map?.remove?.();
+                } catch (cleanupError) {
+                        console.warn('Error while cleaning up failed map instance:', cleanupError);
+                } finally {
+                        map = undefined;
+                }
+
+                throw error;
         }
 }
 

--- a/custom_components/ha_tracker/www/js/utils/map.js
+++ b/custom_components/ha_tracker/www/js/utils/map.js
@@ -1,182 +1,581 @@
-// utils/map.js 
+// utils/map.js
 
 import { loadCSSOnce, loadScriptOnce } from './loader.js';
-import {t} from './i18n.js';
+import { t } from './i18n.js';
 
 export let map;
 
 const v = '1.9.4';
 
 const CDN = {
-	leafletCSS: '/ha-tracker/vendor/leaflet/leaflet.css?v='+v,
-	leafletJS:  '/ha-tracker/vendor/leaflet/leaflet.js?v='+v,
-	geocoderCSS:'/ha-tracker/vendor/leaflet-control-geocoder/Control.Geocoder.css?v='+v,
-	geocoderJS: '/ha-tracker/vendor/leaflet-control-geocoder/Control.Geocoder.js?v='+v,
-	editableJS: '/ha-tracker/vendor/leaflet-editable/Leaflet.Editable.min.js?v='+v,
+        leafletCSS: '/ha-tracker/vendor/leaflet/leaflet.css?v=' + v,
+        leafletJS: '/ha-tracker/vendor/leaflet/leaflet.js?v=' + v,
+        geocoderCSS: '/ha-tracker/vendor/leaflet-control-geocoder/Control.Geocoder.css?v=' + v,
+        geocoderJS: '/ha-tracker/vendor/leaflet-control-geocoder/Control.Geocoder.js?v=' + v,
+        editableJS: '/ha-tracker/vendor/leaflet-editable/Leaflet.Editable.min.js?v=' + v,
+        mapLibreCSS: 'https://unpkg.com/maplibre-gl@3.6.1/dist/maplibre-gl.css',
+        mapLibreJS: 'https://unpkg.com/maplibre-gl@3.6.1/dist/maplibre-gl.js',
+        mapLibreLeafletJS: 'https://unpkg.com/maplibre-gl-leaflet@0.0.21/leaflet-maplibre-gl.js',
 };
 
-async function ensureLeafletLoaded() {
-  await loadCSSOnce(CDN.leafletCSS);
-  await loadCSSOnce(CDN.geocoderCSS);
+const DEFAULT_CENTER = [40.4168, -3.7038]; // Madrid
+const DEFAULT_ZOOM = 6;
+const DEFAULT_PITCH = 45;
+const PITCH_MIN = 0;
+const PITCH_MAX = 65;
+const PITCH_STEP = 5;
+const MAPLIBRE_ATTRIBUTION = '© OpenStreetMap contributors, OpenFreeMap.org — Terrain data © Mapzen, NASA & OpenTopo';
+const HILLSHADE_ATTRIBUTION = 'Hillshade © OpenTopo, SRTM';
 
-  await loadScriptOnce(CDN.leafletJS,  { test: () => !!window.L });
-  await loadScriptOnce(CDN.editableJS, { test: () => !!(window.L && L.Editable) });
-  await loadScriptOnce(CDN.geocoderJS, { test: () => !!(window.L && L.Control && L.Control.Geocoder) });
+export const DEFAULT_3D_PITCH = DEFAULT_PITCH;
+
+const OPENFREEMAP_3D_STYLE = Object.freeze({
+        version: 8,
+        name: 'OpenFreeMap 3D',
+        sources: {
+                openfreemap: {
+                        type: 'raster',
+                        tiles: [
+                                'https://tile.openfreemap.org/{z}/{x}/{y}.png'
+                        ],
+                        minzoom: 0,
+                        maxzoom: 19,
+                        tileSize: 256,
+                        attribution: '© OpenStreetMap contributors, OpenFreeMap.org'
+                },
+                terrain: {
+                        type: 'raster-dem',
+                        tiles: [
+                                'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png'
+                        ],
+                        tileSize: 256,
+                        encoding: 'terrarium',
+                        maxzoom: 14,
+                        attribution: 'Terrain data © Mapzen, NASA'
+                }
+        },
+        terrain: {
+                source: 'terrain',
+                exaggeration: 1.25
+        },
+        light: {
+                anchor: 'viewport',
+                position: [1.4, 90, 75],
+                intensity: 0.45,
+        },
+        layers: [
+                {
+                        id: 'sky',
+                        type: 'sky',
+                        paint: {
+                                'sky-type': 'atmosphere',
+                                'sky-atmosphere-color': '#87a7ff',
+                                'sky-atmosphere-halo-color': '#d7efff',
+                                'sky-atmosphere-sun-intensity': 12,
+                        }
+                },
+                {
+                        id: 'openfreemap-base',
+                        type: 'raster',
+                        source: 'openfreemap',
+                        minzoom: 0,
+                        maxzoom: 19,
+                        paint: {
+                                'raster-brightness-min': 0.85,
+                                'raster-brightness-max': 1.1,
+                                'raster-saturation': 0.1
+                        }
+                },
+                {
+                        id: 'terrain-hillshade',
+                        type: 'hillshade',
+                        source: 'terrain',
+                        paint: {
+                                'hillshade-exaggeration': 0.6,
+                                'hillshade-shadow-color': '#362a1f',
+                                'hillshade-highlight-color': '#fff6df',
+                                'hillshade-accent-color': '#768a42'
+                        }
+                }
+        ]
+});
+
+let desiredPitch = DEFAULT_PITCH;
+let pitchControl = null;
+let currentMaplibreLayer = null;
+let currentMaplibrePitchListener = null;
+
+function cloneStyle(style) {
+        return JSON.parse(JSON.stringify(style));
+}
+
+function createOpenFreeMap3DStyle() {
+        return cloneStyle(OPENFREEMAP_3D_STYLE);
+}
+
+async function ensureLeafletLoaded() {
+        await loadCSSOnce(CDN.leafletCSS);
+        await loadCSSOnce(CDN.geocoderCSS);
+        await loadCSSOnce(CDN.mapLibreCSS);
+
+        await loadScriptOnce(CDN.leafletJS, { test: () => !!window.L });
+        await loadScriptOnce(CDN.editableJS, { test: () => !!(window.L && L.Editable) });
+        await loadScriptOnce(CDN.geocoderJS, { test: () => !!(window.L && L.Control && L.Control.Geocoder) });
+        await loadScriptOnce(CDN.mapLibreJS, { test: () => !!window.maplibregl });
+        await loadScriptOnce(CDN.mapLibreLeafletJS, { test: () => !!(window.L && L.maplibreGL) });
+}
+
+function createHillshadeLayer({ opacity = 0.45, pane = 'overlayPane' } = {}) {
+        return L.tileLayer('https://tiles.wmflabs.org/hillshading/{z}/{x}/{y}.png', {
+                maxZoom: 19,
+                minZoom: 1,
+                opacity,
+                pane,
+                crossOrigin: true,
+                attribution: HILLSHADE_ATTRIBUTION
+        });
+}
+
+function createMapLibreBaseLayer(styleFactory) {
+        const layer = L.maplibreGL({
+                style: styleFactory(),
+                interactive: true,
+                pitch: desiredPitch,
+                bearing: 0,
+                zoom: DEFAULT_ZOOM - 1,
+                minZoom: 2,
+                maxZoom: 19,
+                attributionControl: {
+                        customAttribution: MAPLIBRE_ATTRIBUTION
+                },
+                dragRotate: true,
+                touchPitch: true,
+                touchZoomRotate: true,
+                pitchWithRotate: true
+        });
+        return layer;
+}
+
+function clampPitch(pitch) {
+        return Math.max(PITCH_MIN, Math.min(PITCH_MAX, Number.isFinite(pitch) ? pitch : DEFAULT_PITCH));
+}
+
+function refreshActiveMapLibre(glMap = currentMaplibreLayer?.getMaplibreMap?.()) {
+        if (glMap && typeof glMap.resize === 'function') {
+                glMap.resize();
+        }
+}
+
+function configureTerrain(glMap) {
+        try {
+                const style = glMap.getStyle();
+                if (!style) {
+                        return;
+                }
+
+                const terrainSource = style.terrain?.source;
+                if (terrainSource) {
+                        glMap.setTerrain({ source: terrainSource, exaggeration: OPENFREEMAP_3D_STYLE.terrain.exaggeration });
+                        if (style.layers?.some(l => l.type === 'hillshade')) {
+                                return;
+                        }
+                }
+
+                if (!glMap.getSource('terrain-dem')) {
+                        glMap.addSource('terrain-dem', {
+                                type: 'raster-dem',
+                                tiles: [
+                                        'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png'
+                                ],
+                                tileSize: 256,
+                                encoding: 'terrarium',
+                                maxzoom: 14
+                        });
+                }
+
+                glMap.setTerrain({ source: 'terrain-dem', exaggeration: OPENFREEMAP_3D_STYLE.terrain.exaggeration });
+
+                if (!glMap.getLayer('terrain-hillshade')) {
+                        glMap.addLayer({
+                                id: 'terrain-hillshade',
+                                type: 'hillshade',
+                                source: 'terrain-dem',
+                                paint: {
+                                        'hillshade-exaggeration': 0.6,
+                                        'hillshade-shadow-color': '#362a1f',
+                                        'hillshade-highlight-color': '#fff6df',
+                                        'hillshade-accent-color': '#768a42'
+                                }
+                        });
+                }
+        } catch (err) {
+                console.warn('Unable to configure terrain for MapLibre layer:', err);
+        }
+}
+
+function detachCurrentMapLibre() {
+        if (!currentMaplibreLayer) {
+                return;
+        }
+        const glMap = currentMaplibreLayer.getMaplibreMap?.();
+        if (glMap && currentMaplibrePitchListener) {
+                glMap.off('pitch', currentMaplibrePitchListener);
+        }
+        currentMaplibreLayer = null;
+        currentMaplibrePitchListener = null;
+        updatePitchControlState();
+}
+
+function attachToMapLibreLayer(layer) {
+        if (!layer || typeof layer.getMaplibreMap !== 'function') {
+                detachCurrentMapLibre();
+                return;
+        }
+
+        if (currentMaplibreLayer === layer) {
+                const existing = layer.getMaplibreMap?.();
+                if (existing) {
+                        refreshActiveMapLibre(existing);
+                        updatePitchControlState(existing.getPitch());
+                }
+                return;
+        }
+
+        detachCurrentMapLibre();
+        currentMaplibreLayer = layer;
+
+        const glMap = layer.getMaplibreMap?.();
+        if (!glMap) {
+                updatePitchControlState();
+                return;
+        }
+
+        const syncPitchFromMap = () => {
+                desiredPitch = clampPitch(glMap.getPitch());
+                updatePitchControlState(desiredPitch);
+        };
+        currentMaplibrePitchListener = syncPitchFromMap;
+
+        const setup = () => {
+                configureTerrain(glMap);
+                if (glMap.dragRotate?.enable) {
+                        glMap.dragRotate.enable();
+                }
+                if (glMap.touchZoomRotate?.enableRotation) {
+                        glMap.touchZoomRotate.enableRotation();
+                }
+                if (glMap.touchPitch?.enable) {
+                        glMap.touchPitch.enable();
+                }
+
+                glMap.on('pitch', syncPitchFromMap);
+                setMapPitch(desiredPitch, { animate: false });
+                updatePitchControlState(desiredPitch);
+                refreshActiveMapLibre(glMap);
+        };
+
+        if (glMap.isStyleLoaded && glMap.isStyleLoaded()) {
+                setup();
+        } else {
+                glMap.once('load', setup);
+        }
+}
+
+function updatePitchControlState(pitch = desiredPitch) {
+        desiredPitch = clampPitch(pitch);
+        if (pitchControl) {
+                pitchControl.setPitch(desiredPitch);
+                pitchControl.setEnabled(Boolean(currentMaplibreLayer));
+        }
+}
+
+function createPitchControl() {
+        const PitchControl = L.Control.extend({
+                options: {
+                        position: 'topright'
+                },
+                initialize() {
+                        L.Control.prototype.initialize.call(this);
+                        this._pitch = desiredPitch;
+                        this._enabled = false;
+                },
+                onAdd() {
+                        const container = L.DomUtil.create('div', 'leaflet-bar pitch-control');
+                        this._container = container;
+                        L.DomEvent.disableClickPropagation(container);
+                        L.DomEvent.disableScrollPropagation(container);
+
+                        const label = L.DomUtil.create('span', 'pitch-control__label', container);
+                        this._label = label;
+
+                        const createButton = (text, className, handler) => {
+                                const btn = L.DomUtil.create('a', `pitch-control__btn ${className}`, container);
+                                btn.href = '#';
+                                btn.textContent = text;
+                                L.DomEvent.on(btn, 'click', (ev) => {
+                                        L.DomEvent.stop(ev);
+                                        if (!this._enabled) {
+                                                return;
+                                        }
+                                        handler();
+                                });
+                                return btn;
+                        };
+
+                        this._btnDown = createButton('−', 'pitch-control__btn--down', () => adjustMapPitch(-PITCH_STEP));
+                        this._btnFlat = createButton('2D', 'pitch-control__btn--flat', () => setMapPitch(0));
+                        this._btnDefault = createButton('3D', 'pitch-control__btn--default', () => setMapPitch(DEFAULT_PITCH));
+                        this._btnUp = createButton('+', 'pitch-control__btn--up', () => adjustMapPitch(PITCH_STEP));
+
+                        this._render();
+                        return container;
+                },
+                onRemove() {
+                        if (this._container) {
+                                L.DomEvent.off(this._container);
+                        }
+                },
+                setPitch(pitch) {
+                        this._pitch = Math.round(clampPitch(pitch));
+                        this._render();
+                },
+                setEnabled(enabled) {
+                        this._enabled = Boolean(enabled);
+                        this._render();
+                },
+                _render() {
+                        if (this._label) {
+                                this._label.textContent = `${this._pitch}°`;
+                        }
+                        if (this._container) {
+                                this._container.classList.toggle('pitch-control--disabled', !this._enabled);
+                        }
+                }
+        });
+
+        return new PitchControl();
+}
+
+function adjustMapPitch(delta) {
+        setMapPitch(desiredPitch + delta);
 }
 
 export async function initMap() {
-    try {
-		await ensureLeafletLoaded();
+        try {
+                await ensureLeafletLoaded();
 
-        // Configuración predeterminada del mapa
-        const mapOptions = {
-            center: [40.4168, -3.7038], // Madrid
-            zoom: 6,
-            editable: true,
-			preferCanvas: true,   
-        };
+                const mapOptions = {
+                        center: DEFAULT_CENTER,
+                        zoom: DEFAULT_ZOOM,
+                        editable: true,
+                        preferCanvas: true,
+                };
 
-        // Inicializar el mapa
-        map = L.map('map', mapOptions);
+                map = L.map('map', mapOptions);
 
-        // Capas base
-        const tileLayerOptions = {
-            maxZoom: 19,
-            minZoom: 1,
-			crossOrigin: true, 
-        };
-        const baseLayers = {
-            "OpenStreetMap": L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                ...tileLayerOptions,
-                attribution: '© OpenStreetMap contributors',
-            }),
-            "Esri Satélite": L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-                ...tileLayerOptions,
-                attribution: '© Esri, Maxar, Earthstar Geographics',
-            }),
-        };
-        baseLayers["OpenStreetMap"].addTo(map);
-		
-		map.attributionControl.setPosition('bottomleft');
-		
-        // Control de capas
-        const layersControl = L.control.layers(baseLayers, null, {
-            position: 'topleft'
-        });
-        layersControl.addTo(map);
+                const tileLayerOptions = {
+                        maxZoom: 19,
+                        minZoom: 1,
+                        crossOrigin: true,
+                };
 
-        // Escala en bottom-left para no chocar con el geocoder
-        const scaleCtl = L.control.scale({
-            position: 'bottomleft'
-        }).addTo(map);
+                const openStreetMapLayer = () => L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                        ...tileLayerOptions,
+                        attribution: '© OpenStreetMap contributors'
+                });
 
-        // Ajuste opcional de la posición del selector de capas con CSS/JS
-        const layersControlElement = document.querySelector('.leaflet-control-layers');
-        const zoomControlElement = document.querySelector('.leaflet-control-zoom');
-        if (layersControlElement && zoomControlElement) {
-            const zoomControlRect = zoomControlElement.getBoundingClientRect();
-            layersControlElement.style.position = 'absolute';
-            layersControlElement.style.left = `${zoomControlRect.right}px`;
-        }
+                const esriSatelliteLayer = () => L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+                        ...tileLayerOptions,
+                        attribution: '© Esri, Maxar, Earthstar Geographics'
+                });
 
-        // ---- Invalidations para tamaño/visibilidad ----
-        const invalidate = () => map && map.invalidateSize(true);
+                const openFreeMap2DLayer = () => L.tileLayer('https://tile.openfreemap.org/{z}/{x}/{y}.png', {
+                        ...tileLayerOptions,
+                        attribution: '© OpenStreetMap contributors, OpenFreeMap.org'
+                });
 
-        document.body.addEventListener(
-            "transitionend",
-            (e) => {
-            if (e.target === document.body && e.propertyName === "opacity") {
-                setTimeout(invalidate, 0);
-            }
-        }, {
-            once: true
-        });
+                const baseLayers = {
+                        'OpenFreeMap 3D (Relieve)': createMapLibreBaseLayer(createOpenFreeMap3DStyle),
+                        'OpenFreeMap (2D)': openFreeMap2DLayer(),
+                        'OpenStreetMap': openStreetMapLayer(),
+                        'OpenStreetMap + Relieve (2D)': L.layerGroup([
+                                openStreetMapLayer(),
+                                createHillshadeLayer({ opacity: 0.5, pane: 'overlayPane' })
+                        ]),
+                        'Esri Satélite': esriSatelliteLayer(),
+                };
 
-        const mapEl = document.getElementById("map");
-        if (mapEl && "ResizeObserver" in window) {
-            const ro = new ResizeObserver(() => invalidate());
-            ro.observe(mapEl);
-        }
+                baseLayers['OpenFreeMap 3D (Relieve)'].addTo(map);
+                attachToMapLibreLayer(baseLayers['OpenFreeMap 3D (Relieve)']);
 
-        window.addEventListener("resize", invalidate);
-        document.addEventListener("visibilitychange", () => {
-            if (!document.hidden)
-                setTimeout(invalidate, 0);
-        });
+                map.attributionControl.setPosition('bottomleft');
 
-        setTimeout(invalidate, 350);
+                const overlays = {
+                        'Relieve (Hillshade)': createHillshadeLayer({ opacity: 0.45 })
+                };
 
-        // ---- Geocoder en bottom-left ----
-        const acceptLang = (navigator.languages && navigator.languages.length)
-         ? navigator.languages.join(',')
-         : (navigator.language || 'en');
+                const layersControl = L.control.layers(baseLayers, overlays, {
+                        position: 'topleft'
+                });
+                layersControl.addTo(map);
 
-        const geocoder = L.Control.geocoder({
-            position: 'bottomleft',
-            placeholder: t('search_place'), 
-            collapsed: false,
-            defaultMarkGeocode: false,
-            geocoder: L.Control.Geocoder.nominatim({
-                geocodingQueryParams: {
-                    'accept-language': acceptLang,
-                    limit: 5
-                    // email: 'tu_correo@ejemplo.com'
+                map.on('baselayerchange', (event) => {
+                        if (event?.layer && typeof event.layer.getMaplibreMap === 'function') {
+                                attachToMapLibreLayer(event.layer);
+                        } else {
+                                detachCurrentMapLibre();
+                        }
+                        refreshActiveMapLibre();
+                });
+
+                const invalidate = () => invalidateMapSize({ hard: true });
+
+                document.body.addEventListener(
+                        'transitionend',
+                        (e) => {
+                                if (e.target === document.body && e.propertyName === 'opacity') {
+                                        setTimeout(invalidate, 0);
+                                }
+                        },
+                        {
+                                once: true
+                        }
+                );
+
+                const mapEl = document.getElementById('map');
+                if (mapEl && 'ResizeObserver' in window) {
+                        const ro = new ResizeObserver(() => invalidate());
+                        ro.observe(mapEl);
                 }
-            })
-        })
-            .on('markgeocode', (e) => {
-                const { center, name, bbox } = e.geocode;
-                if (bbox)
-                    map.fitBounds(bbox);
-                else
-                    map.setView(center, 16);
 
-                L.popup({
-                    // opciones útiles:
-                    autoClose: true, // cierra otros popups
-                    closeOnClick: true, // se cierra al clicar el mapa
-                    keepInView: true // intenta mantenerlo en vista al mover/zoom
-                    // className: 'mi-popup' // para estilos personalizados
+                window.addEventListener('resize', invalidate);
+                document.addEventListener('visibilitychange', () => {
+                        if (!document.hidden) {
+                                setTimeout(invalidate, 0);
+                        }
+                });
+
+                pitchControl = createPitchControl();
+                pitchControl.addTo(map);
+                updatePitchControlState();
+
+                setTimeout(() => invalidateMapSize({ hard: true }), 350);
+
+                const acceptLang = (navigator.languages && navigator.languages.length)
+                        ? navigator.languages.join(',')
+                        : (navigator.language || 'en');
+
+                const geocoder = L.Control.geocoder({
+                        position: 'bottomleft',
+                        placeholder: t('search_place'),
+                        collapsed: false,
+                        defaultMarkGeocode: false,
+                        geocoder: L.Control.Geocoder.nominatim({
+                                geocodingQueryParams: {
+                                        'accept-language': acceptLang,
+                                        limit: 5
+                                }
+                        })
                 })
-                .setLatLng(center)
-                .setContent(name)
-                .openOn(map);
-            })
-            .addTo(map);
+                        .on('markgeocode', (e) => {
+                                const { center, name, bbox } = e.geocode;
+                                if (bbox) {
+                                        map.fitBounds(bbox);
+                                } else {
+                                        focusMapOn(center.lat, center.lng, { ensure3d: true });
+                                }
 
-        // Sesgo por vista actual (si quieres búsqueda local; quita bounded para global)
-        function updateSearchBias() {
-            const b = map.getBounds();
-            geocoder.options.geocoder.options.geocodingQueryParams.viewbox =
-                [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()].join(',');
-            geocoder.options.geocoder.options.geocodingQueryParams.bounded = 1; // quita esta línea para global
+                                L.popup({
+                                        autoClose: true,
+                                        closeOnClick: true,
+                                        keepInView: true
+                                })
+                                .setLatLng(center)
+                                .setContent(name)
+                                .openOn(map);
+                        })
+                        .addTo(map);
+
+                function updateSearchBias() {
+                        const b = map.getBounds();
+                        geocoder.options.geocoder.options.geocodingQueryParams.viewbox =
+                                [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()].join(',');
+                        geocoder.options.geocoder.options.geocodingQueryParams.bounded = 1;
+                }
+                map.on('moveend', updateSearchBias);
+                updateSearchBias();
+
+        } catch (error) {
+                console.error('Error starting map:', error);
         }
-        map.on('moveend', updateSearchBias);
-        updateSearchBias();
-		
-		setTimeout(() => map.invalidateSize(true), 0);
-
-    } catch (error) {
-        console.error("Error starting map:", error);
-    }
 }
 
 export function isValidCoordinates(lat, lng) {
-    return lat != null && lng != null && !isNaN(lat) && !isNaN(lng);
+        return lat != null && lng != null && !isNaN(lat) && !isNaN(lng);
+}
+
+export function setMapPitch(pitch, { animate = true } = {}) {
+        desiredPitch = clampPitch(pitch);
+        const glMap = currentMaplibreLayer?.getMaplibreMap?.();
+        if (!glMap) {
+                updatePitchControlState(desiredPitch);
+                return false;
+        }
+
+        if (animate && typeof glMap.easeTo === 'function') {
+                glMap.easeTo({ pitch: desiredPitch, duration: 450 });
+        } else if (typeof glMap.setPitch === 'function') {
+                glMap.setPitch(desiredPitch);
+        }
+
+        updatePitchControlState(desiredPitch);
+        return true;
+}
+
+export function adjustToDefault3DPitch({ animate = true } = {}) {
+        if (isMapLibreBaseActive()) {
+                setMapPitch(DEFAULT_PITCH, { animate });
+        }
+}
+
+export function getMapPitch() {
+        return desiredPitch;
+}
+
+export function isMapLibreBaseActive() {
+        return Boolean(currentMaplibreLayer);
+}
+
+export function invalidateMapSize({ hard = false } = {}) {
+        if (!map) {
+                return;
+        }
+        map.invalidateSize(hard);
+        refreshActiveMapLibre();
+}
+
+export function focusMapOn(lat, lng, { zoom = map?.getZoom(), ensure3d = true, animatePitch = true } = {}) {
+        if (!map || !isValidCoordinates(lat, lng)) {
+                return;
+        }
+        map.setView([lat, lng], zoom);
+        if (ensure3d) {
+                adjustToDefault3DPitch({ animate: animatePitch });
+        }
 }
 
 export function getDistanceFromLatLonInMeters(lat1, lon1, lat2, lon2) {
-    const R = 6371000; // Radio de la Tierra en metros
-    const dLat = degToRad(lat2 - lat1);
-    const dLon = degToRad(lon2 - lon1);
-    const a =
-        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-        Math.cos(degToRad(lat1)) * Math.cos(degToRad(lat2)) *
-        Math.sin(dLon / 2) * Math.sin(dLon / 2);
-    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-    return R * c; // Devuelve la distancia en metros
+        const R = 6371000;
+        const dLat = degToRad(lat2 - lat1);
+        const dLon = degToRad(lon2 - lon1);
+        const a =
+                Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos(degToRad(lat1)) * Math.cos(degToRad(lat2)) *
+                Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
 }
 
 function degToRad(deg) {
-    return deg * (Math.PI / 180);
+        return deg * (Math.PI / 180);
 }

--- a/custom_components/ha_tracker/www/js/utils/ui.js
+++ b/custom_components/ha_tracker/www/js/utils/ui.js
@@ -1,10 +1,10 @@
 
 import { t } from './i18n.js';
-import { map } from './map.js';
+import { map, invalidateMapSize } from './map.js';
 import { use_imperial, SHOW_VISITS } from '../globals.js';
 import { updateZoneActionButtons } from '../screens/zones.js';
 
-const invalidateSoon = () => requestAnimationFrame(() => map?.invalidateSize(true));
+const invalidateSoon = () => requestAnimationFrame(() => invalidateMapSize({ hard: true }));
 
 export async function loadUI() {
     try {


### PR DESCRIPTION
## Summary
- replace the Leaflet-only map bootstrap with a MapLibre-backed configuration that adds OpenFreeMap 3D and relief layers while keeping the existing OpenStreetMap and Esri basemaps
- add a pitch control UI and helper utilities so person, zone and filter screens respect 3D view adjustments when recentering the map
- update styling to accommodate the new pitch control

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e0e5abaa58832a85aa0e64a1f445ca