### PR TITLE
Update MapLibre Leaflet CDN reference

### DIFF
--- a/custom_components/ha_tracker/www/js/utils/map.js
+++ b/custom_components/ha_tracker/www/js/utils/map.js
@@ -8,11 +8,12 @@ export let map;
 const v = '1.9.4';
 
 const CDN = {
-	leafletCSS: '/ha-tracker/vendor/leaflet/leaflet.css?v='+v,
-	leafletJS:  '/ha-tracker/vendor/leaflet/leaflet.js?v='+v,
-	geocoderCSS:'/ha-tracker/vendor/leaflet-control-geocoder/Control.Geocoder.css?v='+v,
-	geocoderJS: '/ha-tracker/vendor/leaflet-control-geocoder/Control.Geocoder.js?v='+v,
-	editableJS: '/ha-tracker/vendor/leaflet-editable/Leaflet.Editable.min.js?v='+v,
+        leafletCSS: '/ha-tracker/vendor/leaflet/leaflet.css?v='+v,
+        leafletJS:  '/ha-tracker/vendor/leaflet/leaflet.js?v='+v,
+        geocoderCSS:'/ha-tracker/vendor/leaflet-control-geocoder/Control.Geocoder.css?v='+v,
+        geocoderJS: '/ha-tracker/vendor/leaflet-control-geocoder/Control.Geocoder.js?v='+v,
+        editableJS: '/ha-tracker/vendor/leaflet-editable/Leaflet.Editable.min.js?v='+v,
+        mapLibreLeafletJS: 'https://unpkg.com/@maplibre/maplibre-gl-leaflet@0.1.3/leaflet-maplibre-gl.js',
 };
 
 async function ensureLeafletLoaded() {


### PR DESCRIPTION
## Summary
- point the MapLibre Leaflet bridge CDN URL to the scoped package on unpkg so future 3D map loads use the maintained distribution

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0f72f31e4832ab7e02d49e39e9663